### PR TITLE
fix: add missing parameter documentation

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -865,6 +865,7 @@ regular).
      * @param {string|Date} from_date From date (String in format of 'yyyy-mm-dd HH:MM:SS' or Date object).
      * @param {string|Date} to_date To date (String in format of 'yyyy-mm-dd HH:MM:SS' or Date object).
      * @param {bool}  [continuous=false] is a bool flag to get continuous data for futures and options instruments. Defaults to false.
+     * @param {bool}  [oi=false] is a bool flag to include OI data for futures and options instruments. Defaults to false.
      */
     self.getHistoricalData = function(instrument_token, interval, from_date, to_date, continuous, oi) {
         continuous = continuous ? 1 : 0;


### PR DESCRIPTION
added missing documentation for `oi` param in `getHistoricalData` method